### PR TITLE
fix: mark zoho-secret-id as isSecret in config_schema

### DIFF
--- a/cmd/baton-zoho-people/config.go
+++ b/cmd/baton-zoho-people/config.go
@@ -15,11 +15,13 @@ var (
 		"zoho-secret-id",
 		field.WithRequired(true),
 		field.WithDescription("Secret ID of the Self Client Application for Zoho."),
+		field.WithIsSecret(true),
 	)
 	refreshTokenField = field.StringField(
 		"zoho-refresh-token",
 		field.WithRequired(true),
 		field.WithDescription("The temporary authorization code to access Zoho APIs."),
+		field.WithIsSecret(true),
 	)
 	domainAccount = field.SelectField(
 		"domain-account",


### PR DESCRIPTION
Marks the `zoho-secret-id` (OAuth client secret) and `zoho-refresh-token` credential fields as secret via `field.WithIsSecret(true)`. They were stored and displayed in plain text. `zoho-client-id` is the public client ID and stays non-secret.

This connector has no committed `config_schema.json` (config is defined in Go), so the field option is authoritative — there is no generated schema to regenerate.

> BREAKING: adding `isSecret: true` to these fields changes how existing configurations are stored. Customers with existing connector configurations will need to re-enter credentials after this change is deployed.

<!-- stargate-audit -->