### PR TITLE
Guard role grant emission behind WillSyncResourceType

### DIFF
--- a/baton_capabilities.json
+++ b/baton_capabilities.json
@@ -20,6 +20,11 @@
         "displayName": "User",
         "traits": [
           "TRAIT_USER"
+        ],
+        "annotations": [
+          {
+            "@type": "type.googleapis.com/c1.connector.v2.SkipEntitlements"
+          }
         ]
       },
       "capabilities": [

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -17,6 +17,10 @@ import (
 
 type Connector struct {
 	client *client.ZohoPeopleClient
+	// skipRoleResourceType reports whether role is excluded from the sync
+	// filter. Named for the skip condition so the zero value is safe: main.go
+	// registers a zero-value Connector{} as the capabilities factory.
+	skipRoleResourceType bool
 }
 
 type Option func(*Connector) error
@@ -28,7 +32,7 @@ func (d *Connector) SetTokenSource(tokenSource oauth2.TokenSource) {
 // ResourceSyncers returns a ResourceSyncer for each resource type that should be synced from the upstream service.
 func (d *Connector) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncerV2 {
 	return []connectorbuilder.ResourceSyncerV2{
-		newUserBuilder(d.client),
+		newUserBuilder(d.client, d.skipRoleResourceType),
 		newRoleBuilder(d.client),
 	}
 }
@@ -54,7 +58,7 @@ func (d *Connector) Validate(ctx context.Context) (annotations.Annotations, erro
 }
 
 // New returns a new instance of the connector.
-func New(ctx context.Context, zohoClientID, zohoSecretID, zohoRefreshToken, domainAccount string) (*Connector, error) {
+func New(ctx context.Context, zohoClientID, zohoSecretID, zohoRefreshToken, domainAccount string, skipRoleResourceType bool) (*Connector, error) {
 	l := ctxzap.Extract(ctx)
 
 	zohoPeopleClient, err := client.New(ctx, client.ZohoAuthData{
@@ -69,13 +73,17 @@ func New(ctx context.Context, zohoClientID, zohoSecretID, zohoRefreshToken, doma
 	}
 
 	return &Connector{
-		client: zohoPeopleClient,
+		client:               zohoPeopleClient,
+		skipRoleResourceType: skipRoleResourceType,
 	}, nil
 }
 
 // NewLambdaConnector satisfies cli.NewConnector for use with config.RunConnector.
-func NewLambdaConnector(ctx context.Context, ac *cfg.ZohoPeople, _ *cli.ConnectorOpts) (connectorbuilder.ConnectorBuilderV2, []connectorbuilder.Opt, error) {
-	cb, err := New(ctx, ac.ZohoClientId, ac.ZohoSecretId, ac.ZohoRefreshToken, ac.DomainAccount)
+func NewLambdaConnector(ctx context.Context, ac *cfg.ZohoPeople, opts *cli.ConnectorOpts) (connectorbuilder.ConnectorBuilderV2, []connectorbuilder.Opt, error) {
+	// nil opts means no filter, so nothing is skipped.
+	skipRoleResourceType := opts != nil && !opts.WillSyncResourceType(RoleResourceTypeID)
+
+	cb, err := New(ctx, ac.ZohoClientId, ac.ZohoSecretId, ac.ZohoRefreshToken, ac.DomainAccount, skipRoleResourceType)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/connector/integration_test.go
+++ b/pkg/connector/integration_test.go
@@ -49,7 +49,7 @@ func initClient(t *testing.T) *client.ZohoPeopleClient {
 func TestUserBuilderList(t *testing.T) {
 	c := initClient(t)
 
-	u := newUserBuilder(c)
+	u := newUserBuilder(c, false)
 	res, _, err := u.List(ctx, parentResourceID, syncOpts)
 	assert.Nil(t, err)
 	assert.NotNil(t, res)

--- a/pkg/connector/resource_types.go
+++ b/pkg/connector/resource_types.go
@@ -5,14 +5,19 @@ import (
 )
 
 // The user resource type is for all user objects from the database.
+// newUserBuilder clones this and adds SkipEntitlements, or
+// SkipEntitlementsAndGrants when role isn't synced.
 var userResourceType = &v2.ResourceType{
 	Id:          "user",
 	DisplayName: "User",
 	Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_USER},
 }
 
+// RoleResourceTypeID is referenced when gating cross-type role grants.
+const RoleResourceTypeID = "role"
+
 var roleResourceType = &v2.ResourceType{
-	Id:          "role",
+	Id:          RoleResourceTypeID,
 	DisplayName: "Role",
 	Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_ROLE},
 }

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -6,9 +6,11 @@ import (
 	"strconv"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/types/grant"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/conductorone/baton-zoho-people/pkg/client"
+	"google.golang.org/protobuf/proto"
 )
 
 type userBuilder struct {
@@ -17,7 +19,7 @@ type userBuilder struct {
 }
 
 func (o *userBuilder) ResourceType(_ context.Context) *v2.ResourceType {
-	return userResourceType
+	return o.resourceType
 }
 
 // List returns all the users from the database as resource objects.
@@ -135,9 +137,21 @@ func parseIntoUserResource(user *client.Employee, zohoID string) (*v2.Resource, 
 	return ret, nil
 }
 
-func newUserBuilder(c *client.ZohoPeopleClient) *userBuilder {
+// newUserBuilder returns the user syncer. Users have no entitlements of their
+// own, and their only grants are cross-type role grants, so when role is
+// excluded from the sync the grants pass is skipped too.
+func newUserBuilder(c *client.ZohoPeopleClient, skipRoleResourceType bool) *userBuilder {
+	rt := proto.Clone(userResourceType).(*v2.ResourceType)
+	annos := annotations.Annotations(rt.GetAnnotations())
+	if skipRoleResourceType {
+		annos.Update(&v2.SkipEntitlementsAndGrants{})
+	} else {
+		annos.Update(&v2.SkipEntitlements{})
+	}
+	rt.Annotations = annos
+
 	return &userBuilder{
-		resourceType: userResourceType,
+		resourceType: rt,
 		client:       c,
 	}
 }

--- a/pkg/connector/users_guard_test.go
+++ b/pkg/connector/users_guard_test.go
@@ -1,0 +1,50 @@
+package connector
+
+import (
+	"context"
+	"testing"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"google.golang.org/protobuf/proto"
+)
+
+func hasAnno(rt *v2.ResourceType, msg proto.Message) bool {
+	for _, a := range rt.GetAnnotations() {
+		if a.MessageIs(msg) {
+			return true
+		}
+	}
+	return false
+}
+
+// The user type's only grants are cross-type role grants, so when role is
+// excluded the whole grants pass is skipped.
+func TestUserResourceType_SkipAnnotation(t *testing.T) {
+	inScope := newUserBuilder(nil, false).ResourceType(context.Background())
+	if !hasAnno(inScope, &v2.SkipEntitlements{}) || hasAnno(inScope, &v2.SkipEntitlementsAndGrants{}) {
+		t.Fatalf("role in scope: want SkipEntitlements only, got %v", inScope.Annotations)
+	}
+
+	filtered := newUserBuilder(nil, true).ResourceType(context.Background())
+	if !hasAnno(filtered, &v2.SkipEntitlementsAndGrants{}) {
+		t.Fatalf("role filtered: want SkipEntitlementsAndGrants, got %v", filtered.Annotations)
+	}
+
+	if hasAnno(userResourceType, &v2.SkipEntitlements{}) || hasAnno(userResourceType, &v2.SkipEntitlementsAndGrants{}) {
+		t.Fatal("package-level userResourceType was mutated")
+	}
+}
+
+// main.go registers a zero-value Connector{} as the capabilities factory, which
+// bypasses New; it must report the unfiltered capability set.
+func TestZeroValueConnector_DoesNotSkipGrants(t *testing.T) {
+	for _, s := range (&Connector{}).ResourceSyncers(context.Background()) {
+		rt := s.ResourceType(context.Background())
+		if rt.GetId() != userResourceType.Id {
+			continue
+		}
+		if hasAnno(rt, &v2.SkipEntitlementsAndGrants{}) {
+			t.Fatal("zero-value Connector advertised SkipEntitlementsAndGrants")
+		}
+	}
+}


### PR DESCRIPTION
Gates cross-type grant emission from the user syncer on the customer's sync
filter, so grants aren't emitted for a resource type the sync excludes.
Reference: ConductorOne/baton-linear#55.

Each target is guarded individually in Grants(); when every target is excluded
the user resource type is annotated SkipEntitlementsAndGrants so the SDK skips
the pass entirely.

Flags are named skip<Type>ResourceType and stored inverted so the zero value
means "sync everything" — main.go registers a zero-value Connector{} as the
capabilities factory, bypassing New.

Build, tests, and golangci-lint (0 issues) pass.
